### PR TITLE
feat: add only_ros option

### DIFF
--- a/src/rotop/gui_main.py
+++ b/src/rotop/gui_main.py
@@ -197,7 +197,7 @@ def gui_loop(view: GuiView):
 
 def gui_main(args):
   global g_reset_history_df
-  top_runner = TopRunner(args.filter, args.interval)
+  top_runner = TopRunner(args.interval, args.filter)
   data_container = DataContainer(args.csv)
 
   view = GuiView()
@@ -206,7 +206,7 @@ def gui_main(args):
 
   try:
     while True:
-      result_lines, result_show_all_lines = top_runner.run(args.num_process, True)
+      result_lines, result_show_all_lines = top_runner.run(args.num_process, True, args.only_ros)
       if result_show_all_lines is None:
         time.sleep(0.1)
         continue

--- a/src/rotop/rotop.py
+++ b/src/rotop/rotop.py
@@ -34,13 +34,13 @@ def main_curses(stdscr, args):
   curses.curs_set(0)
   stdscr.timeout(10)
 
-  top_runner = TopRunner(args.filter, args.interval)
+  top_runner = TopRunner(args.interval, args.filter)
   data_container = DataContainer(args.csv)
 
   try:
     while True:
       max_y, max_x = stdscr.getmaxyx()
-      result_lines, result_show_all_lines = top_runner.run(max(max_y, args.num_process), max_x>160)
+      result_lines, result_show_all_lines = top_runner.run(max(max_y, args.num_process), max_x>160, args.only_ros)
       if result_show_all_lines is None:
         time.sleep(0.1)
         continue
@@ -69,12 +69,15 @@ def parse_args():
   parser.add_argument('--csv', action='store_true', default=False)
   parser.add_argument('--gui', action='store_true', default=False)
   parser.add_argument('--num_process', type=int, default=30)
+  parser.add_argument('--only_ros', action='store_true', default=False)
+  
   args = parser.parse_args()
 
   logger.debug(f'filter: {args.filter}')
   logger.debug(f'csv: {args.csv}')
   logger.debug(f'gui: {args.gui}')
   logger.debug(f'num_process: {args.num_process}')
+  logger.debug(f'only_ros: {args.only_ros}')
 
   return args
 


### PR DESCRIPTION
# Why this PR is needed

- To support `--only_ros` option as described in #2 

# What this PR changes

- Add `--only_ros` to display ROS related processes only

## Note

- I use `--ros-arg|/opt/ros` to check if the process is ROS or not, although I use `['__node', '__ns']` to parse command name. It's because I'm not exactly sure that any ROS node has `['__node', '__ns']` argument

# Result

### without `--only_ros`

![image](https://github.com/iwatake2222/rotop/assets/11009876/87b4ff85-0c6f-4522-a0c2-31630ddecb49)

### with `--only_ros`

![image](https://github.com/iwatake2222/rotop/assets/11009876/5d5229c5-c55b-4441-9aaa-98633c0b4338)

