### PR TITLE
fix: high CPU load on virtual machine

### DIFF
--- a/src/rotop/gui_main.py
+++ b/src/rotop/gui_main.py
@@ -88,7 +88,7 @@ class GuiView:
 
   def start_dpg(self):
     dpg.create_context()
-    dpg.create_viewport(title='rotop')
+    dpg.create_viewport(title='rotop', width=800, height=600)
     dpg.setup_dearpygui()
 
     with dpg.window(label='window', no_collapse=True, no_title_bar=True, no_move=True, no_resize=True) as self.dpg_window_id:


### PR DESCRIPTION
# Why this feature is needed

## Background

- As reported in #3 , CPU load becomes very high when running `rotop` on a virtual machine like WSL, Docker and AWS EC2

## Research

- `rotop` uses [DearPyGui](https://github.com/hoffstadt/DearPyGui). The simple [demo ](https://github.com/hoffstadt/DearPyGui#demo)provided by DearPyGui also shows the same issue and it's probably caused by very high FPS (I checked the FPS of the demo and it was 222 FPS, which causes 527% of CPU usage on AWS EC2!)
- It seems that the GUI library has the problem on a virtual machine

![a](https://github.com/iwatake2222/rotop/assets/11009876/07365b25-c62a-4c74-90a7-31f6970e8f5e)

# What changed

- As a workaround, I added the logic to control FPS manually (FPS is limited to 10 FPS)
- The CPU usage is decreased to 5.6% on WSL on Windows 11

![Clipboard01](https://github.com/iwatake2222/rotop/assets/11009876/bf9890dc-185b-4c1f-98e8-66c327e1e7d3)

# Note

- It's just a workaround, and CPU load still may be a little high in some environments