### PR TITLE
Add help text to argparse

### DIFF
--- a/src/rotop/rotop.py
+++ b/src/rotop/rotop.py
@@ -64,13 +64,13 @@ def main_curses(stdscr, args):
 def parse_args():
   parser = argparse.ArgumentParser(
     description=f'rotop: top for ROS 2, version {version}')
-  parser.add_argument('--interval', type=float, default=2)
-  parser.add_argument('--filter', type=str, default='.*')
-  parser.add_argument('--csv', action='store_true', default=False)
-  parser.add_argument('--gui', action='store_true', default=False)
-  parser.add_argument('--num_process', type=int, default=30)
-  parser.add_argument('--only_ros', action='store_true', default=False)
-  
+  parser.add_argument('--interval', type=float, default=2, help="Update interval in seconds. Similar to the -d option of top.")
+  parser.add_argument('--filter', type=str, default='.*', help="Only show processes fitting to this regular expression.")
+  parser.add_argument('--csv', action='store_true', default=False, help="Activate saving data to csv file.")
+  parser.add_argument('--gui', action='store_true', default=False, help="Use GUI including plotting of CPU loads.")
+  parser.add_argument('--num_process', type=int, default=30, help="Maximum number of processes that will be shown.")
+  parser.add_argument('--only_ros', action='store_true', default=False, help="List only ROS 2 node processes.")
+
   args = parser.parse_args()
 
   logger.debug(f'filter: {args.filter}')


### PR DESCRIPTION
Small PR that adds help text to rotop, making it a bit simpler to understand the options for new users.
You can also adapt the text if you want. I just think giving some more information is helpful. Otherwise some things are not clear, e.g. "--csv" could also expect a file name afterwards.

Current output:
```
➜  python3 main.py --help
usage: main.py [-h] [--interval INTERVAL] [--filter FILTER] [--csv] [--gui]
               [--num_process NUM_PROCESS] [--only_ros]

rotop: top for ROS 2, version 0.0.0

options:
  -h, --help            show this help message and exit
  --interval INTERVAL   Update interval in seconds. Similar to the -d option of top.
  --filter FILTER       Only show processes fitting to this regular expression.
  --csv                 Activate saving data to csv file.
  --gui                 Use GUI including plotting of CPU loads.
  --num_process NUM_PROCESS
                        Maximum number of processes that will be shown.
  --only_ros            List only ROS 2 node processes.

```