### PR TITLE
fix: annotation for old python

### DIFF
--- a/src/rotop/data_container.py
+++ b/src/rotop/data_container.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 import datetime
 import time
 import os

--- a/src/rotop/gui_main.py
+++ b/src/rotop/gui_main.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 import pandas as pd
 import threading
 import time

--- a/src/rotop/rotop.py
+++ b/src/rotop/rotop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 import argparse
 import curses
 import time

--- a/src/rotop/top_runner.py
+++ b/src/rotop/top_runner.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 import atexit
 import pexpect
 import re

--- a/src/rotop/utility.py
+++ b/src/rotop/utility.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 import logging
 
 


### PR DESCRIPTION
Fix #10 , but still need `pip3 install numpy -U`
